### PR TITLE
feat: Added initial html markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,28 +2,42 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"> <!-- displays site properly based on user's device -->
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png">
-  
   <title>Frontend Mentor | Coding Bootcamp Testimonials Slider</title>
-
 </head>
 <body>
+  <main class="testimonial-slider-container">
+    <section class="slider-slides">
+      <div class="slide">
+        <div class="image-container">
+          <img src="./images/image-tanya.jpg" alt="Tanya Sinclair, UX Engineer">
+        </div>
+        <p>“ I’ve been interested in coding for a while but never taken the jump, until now. I couldn’t recommend this course enough. I’m now in the job of my dreams and so excited about the future. ”</p>
+        <p>Tanya Sinclair</p>
+        <p>UX Engineer</p>
+      </div>
+      <div class="slide">
+        <div class="image-container">
+          <img src="./images/image-john.jpg" alt="John Tarkpor, Junior Front-end Developer">
+        </div>
+        <p>“ If you want to lay the best foundation possible I’d recommend taking this course. The depth the instructors go into is incredible. I now feel so confident about starting up as a professional developer. ”</p>
+        <p>John Tarkpor</p>
+        <p>Junior Front-end Developer</p>
+      </div>
+    </section>
 
-  “ I’ve been interested in coding for a while but never taken the jump, until now. 
-  I couldn’t recommend this course enough. I’m now in the job of my dreams and so 
-  excited about the future. ”
-
-  Tanya Sinclair
-  UX Engineer
-
-  “ If you want to lay the best foundation possible I’d recommend taking this course. 
-  The depth the instructors go into is incredible. I now feel so confident about 
-  starting up as a professional developer. ”
-
-  John Tarkpor
-  Junior Front-end Developer
+    <div class="slider-control previous">
+      <button aria-label="previous">
+        <img src="./images/icon-prev.svg" alt="Previous">
+      </button>
+    </div>
+    <div class="slider-control next">
+      <button aria-label="next"> 
+        <img src="./images/icon-next.svg" alt="Next">
+      </button>
+    </div>
+  </main>
   
 </body>
 </html>


### PR DESCRIPTION
Closes #1 

Added the initial HTML markup. I kept the slider buttons outside of the slides, it can't be repeated on each slide. To position the nav like the original design I think that using a grid with grid-template-areas would be the most efficient way. It could be a complex layout but the other option of having multiple controls for each slide is not a good idea. 

